### PR TITLE
Fix error when trying to load nonexistent template

### DIFF
--- a/httpie/cli/argtemplate.py
+++ b/httpie/cli/argtemplate.py
@@ -106,11 +106,15 @@ def load_template(arg):
         except json.JSONDecodeError:
             pass
         args = []
-        args_dict = stored_templates[arg]
+        args_dict = None
+        try:
+            args_dict = stored_templates[arg]
+        except KeyError:
+            print(f"Template '{arg}' does not exist.")
         if args_dict is not None:
             args.append(args_dict.pop('method'))
-        args.append(args_dict.pop('url'))
-        data_dict = args_dict.pop('data')
-        for _, value in data_dict.items():
-            args.append(value)
+            args.append(args_dict.pop('url'))
+            data_dict = args_dict.pop('data')
+            for _, value in data_dict.items():
+                args.append(value)
         return args

--- a/httpie/core.py
+++ b/httpie/core.py
@@ -48,10 +48,10 @@ def raw_main(
     if use_default_options and env.config.default_options:
         args = env.config.default_options + args
 
-    if args[0] is not None:
+    if len(args) > 0:
         # Unlike when running httpie commands without templates, when creating templates you need to specify an http method
-        # http template <name> <method> <url> |<REQUEST_ITEM>|
         if (args[0] == "template"):
+            # http template <name> <method> <url> |<REQUEST_ITEM>|
             if len(args) < 2:
                 print("No template name was specified")
                 return ExitStatus.ERROR
@@ -61,9 +61,8 @@ def raw_main(
             from httpie.cli.argtemplate import store_json_template
             store_json_template(args[1:])
             return ExitStatus.SUCCESS
-
-        # http runt <name>
-        if (args[0] == "runt"):
+        elif (args[0] == "runt"):
+            # http runt <name>
             if len(args) < 2:
                 print("No template name was specified")
                 return ExitStatus.ERROR
@@ -72,9 +71,8 @@ def raw_main(
                 return ExitStatus.ERROR
             from httpie.cli.argtemplate import store_json_template, load_template
             args = load_template(args[1])
-
-        # http editt <name> <request_item> <new_value>
-        if (args[0] == "editt"):
+        elif (args[0] == "editt"):
+            # http editt <name> <request_item> <new_value>
             if len(args) < 2:
                 print("No template name was specified")
                 return ExitStatus.ERROR

--- a/tests/test_argtemplate.py
+++ b/tests/test_argtemplate.py
@@ -228,7 +228,7 @@ class TestLoadTemplate:
             for i in range(len(args) - 3):
                 assert args[i + 3] == loaded_args[i]
 
-    def test_load_template_not_found(self):
+    def test_load_template_not_found(self, capsys):
         """
         Tests loading a template when the name of the template to load cannot be found in the template file
         """
@@ -239,4 +239,6 @@ class TestLoadTemplate:
             args = command.split()
 
             loaded_args = httpie.cli.argtemplate.load_template(args[2])
-            assert loaded_args is None
+            out, _ = capsys.readouterr()
+            assert loaded_args == []
+            assert "Template 'test_template' does not exist." in out


### PR DESCRIPTION
This makes sure that there is an error message printed when trying to use a template that doesn't exist and makes sure that no unhandled exceptions occur.

Fixes #10